### PR TITLE
Fixes for Magento 2.3

### DIFF
--- a/Helper/ClientTicketData.php
+++ b/Helper/ClientTicketData.php
@@ -16,8 +16,8 @@ class ClientTicketData extends \Magento\Framework\App\Helper\AbstractHelper
 
 	public function generateTicketRequestData()
 	{
-		$username = $this->getConfigValue('monetra_username');
-		$password = $this->_encryptor->decrypt($this->getConfigValue('monetra_password'));
+		$username = $this->getConfigValue('monetra_ticket_username');
+		$password = $this->_encryptor->decrypt($this->getConfigValue('monetra_ticket_password'));
 
 		$req_sequence = mt_rand();
 		$req_timestamp = time();
@@ -50,7 +50,7 @@ class ClientTicketData extends \Magento\Framework\App\Helper\AbstractHelper
 
 		$payment_server = $this->getConfigValue('payment_server');
 		if ($payment_server === 'custom') {
-			$payment_form_host = 'https://' . $this->getConfigValue('monetra_host') . ':' . $this->getConfigValue('monetra_port');
+			$payment_form_host = 'https://' . $this->getConfigValue('monetra_host') . ':' . $this->getConfigValue('monetra_ticket_port');
 		} elseif ($payment_server === 'live') {
 			$payment_form_host = 'https://' . MonetraInterface::LIVE_SERVER_URL . ':' . MonetraInterface::LIVE_SERVER_PORT;
 		} else {

--- a/Helper/MonetraInterface.php
+++ b/Helper/MonetraInterface.php
@@ -18,9 +18,9 @@ class MonetraInterface
 
 	public function __construct($config_data)
 	{
-		$this->origin = 'https://' . $config_data['host'] . ':' . $config_data['port'];
-		$this->username = $config_data['username'];
-		$this->password = $config_data['password'];
+		$this->origin = 'https://' . $config_data['host'] . ':' . $config_data['monetra_port'];
+		$this->username = $config_data['monetra_username'];
+		$this->password = $config_data['monetra_password'];
 	}
 
 	public function authorize($ticket, $amount, $order)

--- a/Model/ClientTicket.php
+++ b/Model/ClientTicket.php
@@ -172,23 +172,31 @@ class ClientTicket extends \Magento\Payment\Model\Method\Cc
 		$payment_server = $this->getConfigData('payment_server');
 		if ($payment_server === 'custom') {
 			$host = $this->getConfigData('monetra_host');
-			$port = $this->getConfigData('monetra_port');
+			$monetra_port = $this->getConfigData('monetra_port');
+			$monetra_ticket_port = $this->getConfigData('monetra_ticket_port');
 		} elseif ($payment_server === 'live') {
 			$host = MonetraInterface::LIVE_SERVER_URL;
-			$port = MonetraInterface::LIVE_SERVER_PORT;
+			$monetra_port = MonetraInterface::LIVE_SERVER_PORT;
+			$monetra_ticket_port = MonetraInterface::LIVE_SERVER_PORT;
 		} else {
 			$host = MonetraInterface::TEST_SERVER_URL;
-			$port = MonetraInterface::TEST_SERVER_PORT;
+			$monetra_port = MonetraInterface::TEST_SERVER_PORT;
+			$monetra_ticket_port = MonetraInterface::TEST_SERVER_PORT;
 		}
 		return [
 			'host' => $host,
-			'port' => $port,
-			'username' => $this->getConfigData('monetra_username'),
-			'password' => $this->_encryptor->decrypt($this->getConfigData('monetra_password'))
+			'monetra_port' => $monetra_port,
+			'monetra_username' => $this->getConfigData('monetra_username'),
+			'monetra_password' => $this->_encryptor->decrypt($this->getConfigData('monetra_password')),
+			'monetra_ticket_port' => $monetra_ticket_port,
+			'monetra_ticket_username' => $this->getConfigData('monetra_ticket_username'),
+			'monetra_ticket_password' => $this->_encryptor->decrypt($this->getConfigData('monetra_ticket_password'))
 		];
 	}
 
 	public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = NULL){
     	       return $this->getConfigData('active') || $this->getConfigData('active');
     	}
+
+
 }

--- a/Model/ClientTicket.php
+++ b/Model/ClientTicket.php
@@ -187,4 +187,8 @@ class ClientTicket extends \Magento\Payment\Model\Method\Cc
 			'password' => $this->_encryptor->decrypt($this->getConfigData('monetra_password'))
 		];
 	}
+
+	public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = NULL){
+    	       return $this->getConfigData('active') || $this->getConfigData('active');
+    	}
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -4,60 +4,70 @@
 		<section id="payment">
 			<group id="monetra_client_ticket" translate="label" type="text" sortOrder="500" showInDefault="1" showInWebsite="1" showInStore="1">
 				<label>Monetra PaymentFrame</label>
-				<field id="active" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="active" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>Enabled</label>
 					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
 				</field>
-				<field id="payment_action" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="payment_action" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>Payment Action</label>
 					<source_model>Monetra\Monetra\Model\Source\PaymentAction</source_model>
 				</field>
-				<field id="title" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="1">
+				<field id="title" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1">
 					<label>Title</label>
 				</field>
-				<field id="order_status" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="order_status" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>New Order Status</label>
 					<source_model>Magento\Sales\Model\Config\Source\Order\Status\Processing</source_model>
 				</field>
-				<field id="payment_server" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="payment_server" translate="label" type="select" sortOrder="25" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>Payment Server</label>
 					<source_model>Monetra\Monetra\Model\Source\PaymentServer</source_model>
 				</field>
-				<field id="monetra_host" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="monetra_host" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>Monetra Host</label>
 				</field>
-				<field id="monetra_port" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="0">
-					<label>Monetra Port</label>
+				<field id="monetra_port" translate="label" type="text" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="0">
+					<label>Monetra Post Port</label>
 				</field>
-				<field id="monetra_username" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="0">
-					<label>Monetra Username</label>
+				<field id="monetra_username" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
+					<label>Monetra Post Username</label>
 				</field>
-				<field id="monetra_password" translate="label" type="obscure" showInDefault="1" showInWebsite="1" showInStore="0">
-					<label>Monetra Password</label>
+				<field id="monetra_password" translate="label" type="obscure" sortOrder="45" showInDefault="1" showInWebsite="1" showInStore="0">
+					<label>Monetra Post Password</label>
 					<backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
 				</field>
-				<field id="expdate_format" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="monetra_ticket_port" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
+					<label>Monetra Ticket Port</label>
+				</field>
+				<field id="monetra_ticket_username" translate="label" type="text" sortOrder="55" showInDefault="1" showInWebsite="1" showInStore="0">
+					<label>Monetra Ticket Username</label>
+				</field>
+				<field id="monetra_ticket_password" translate="label" type="obscure" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
+					<label>Monetra Ticket Password</label>
+					<backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+				</field>
+				<field id="expdate_format" translate="label" type="select" sortOrder="65" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>Expiration Date Format</label>
 					<source_model>Monetra\Monetra\Model\Source\ExpDateFormat</source_model>
 				</field>
-				<field id="auto_reload" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="auto_reload" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>Auto-reload</label>
 					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
 				</field>
-				<field id="autocomplete" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="autocomplete" translate="label" type="select" sortOrder="75" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>Autocomplete</label>
 					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
 				</field>
-				<field id="css_url" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="css_url" translate="label" type="text" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>CSS Path</label>
 				</field>
-				<field id="user_facing_deny_message" translate="label" type="textarea" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="user_facing_deny_message" translate="label" sortOrder="85" type="textarea" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>User-Facing Payment Denial Message</label>
 				</field>
-				<field id="user_facing_error_message" translate="label" type="textarea" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="user_facing_error_message" translate="label" sortOrder="90" type="textarea" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>User-Facing Payment Error Message</label>
 				</field>
-				<field id="sort_order" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="0">
+				<field id="sort_order" translate="label" type="text" sortOrder="95" showInDefault="1" showInWebsite="1" showInStore="0">
 					<label>Sort Order</label>
 					<frontend_class>validate-number</frontend_class>
 				</field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -18,16 +18,19 @@
 		<dev>
 		  <js>
 		    <minify_exclude>
-		      <monetra_js>
-			/PaymentFrame/
-		      </monetra_js>
+		      <monetra2>
+			PaymentFrame/PaymentFrame.js
+		      </monetra2>
+		      <monetra2>
+			PaymentFrame/PaymentFrameInternal.js
+		      </monetra2>
 		    </minify_exclude>
 		  </js>
 		  <css>
 		    <minify_exclude>
-		      <monetra_css>
-			/PaymentFrame/
-		      </monetra_css>
+		      <monetra>
+			PaymentFrame.css
+		      </monetra>
 		    </minify_exclude>
 		  </css>
 		</dev>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -18,12 +18,18 @@
 		<dev>
 		  <js>
 		    <minify_exclude>
-		      <monetra>
-			PaymentFrame/PaymentFrame.js
-		      </monetra>
+		      <monetra_js>
+			/PaymentFrame/
+		      </monetra_js>
 		    </minify_exclude>
 		  </js>
+		  <css>
+		    <minify_exclude>
+		      <monetra_css>
+			/PaymentFrame/
+		      </monetra_css>
+		    </minify_exclude>
+		  </css>
 		</dev>
-		
 	</default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,7 +3,7 @@
 	<default>
 		<payment>
 			<monetra_client_ticket>
-				<active>0</active>
+				<active>1</active>
 				<model>Monetra\Monetra\Model\ClientTicket</model>
 				<order_status>processing</order_status>
 				<payment_action>authorize</payment_action>
@@ -15,5 +15,13 @@
 				<user_facing_error_message>We experienced a problem while attempting to process your payment. Please contact support for more information.</user_facing_error_message>
 			</monetra_client_ticket>
 		</payment>
+		<dev>
+		  <js>
+		    <minify_exclude>
+		      PaymentFrame.js
+		    </minify_exclude>
+		  </js>
+		</dev>
+		
 	</default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -18,7 +18,9 @@
 		<dev>
 		  <js>
 		    <minify_exclude>
-		      PaymentFrame.js
+		      <monetra>
+			PaymentFrame/PaymentFrame.js
+		      </monetra>
 		    </minify_exclude>
 		  </js>
 		</dev>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -4,5 +4,6 @@
 		<module name="Magento_Sales"/>
 		<module name="Magento_Quote"/>
 		<module name="Magento_Checkout"/>
+		<module name="Magento_Payment"/>		
 	</module>
 </config>


### PR DESCRIPTION
Fixes issue when minification of js files is enabled in Magento.  When enabled, the call to /PaymentFrame/PaymentFrame.js is converted to /PaymentFrame/PaymentFrame.min.js which fails as the current version of Monetra doesn't serve a minified version of PaymentFrame.js

Also fixes issue of payment method not showing up at all in 2.3.3 because IsAvailable function is missing.
