### PR TITLE
Enable CCV and AVS Status in Magento 2 for Signifyd

### DIFF
--- a/Helper/MonetraInterface.php
+++ b/Helper/MonetraInterface.php
@@ -185,6 +185,11 @@ class MonetraInterface extends \Magento\Framework\App\Helper\AbstractHelper
 		}
 	}
 
+	public function transaction($ttid)
+	{
+		return $this->request('GET', 'transaction/' . $ttid);
+	}
+
 	public function request($credentials, $method, $path, $data = [])
 	{
 		$url = $this->origin . '/api/v2/' . $path;

--- a/Model/ClientTicket.php
+++ b/Model/ClientTicket.php
@@ -168,22 +168,13 @@ class ClientTicket extends \Magento\Payment\Model\Method\Cc
 		}
 
 		$transaction_id = $response['ttid'];
-
 		if ($auto_tokenize && !$customer_selected_tokenize && isset($response['token'])) {
 			$transaction_id .= "-" . $response['token'];
 		}
 
-		// Get Transaction Details
-		$transaction = $this->monetraInterface->transaction($transaction_id);
-		$expDate = \DateTime::createFromFormat('my', $transaction['expdate'] ?? '0101');
-		$expDateMonth = $expDate->format('n') ?? date('n');
-		$expDateYear = $expDate->format('Y') ?? date('Y');
+		$this->handleSignify($transaction_id, $payment);
 
 		$payment->setTransactionId($transaction_id);
-		$payment->setCcApproval($transaction['cv'] ?? 'GOOD');
-		$payment->setCcAvsStatus($transaction['avs'] ?? 'GOOD');
-		$payment->setCcExpMonth($expDateMonth);
-		$payment->setCcExpYear($expDateYear);
 		$payment->setIsTransactionClosed(false);
 
 		return $this;
@@ -281,19 +272,9 @@ class ClientTicket extends \Magento\Payment\Model\Method\Cc
 			$this->handleAuthResponse($response, $payment, $paymentToken);
 		}
 
-		$transaction_id = $response['ttid'];
+		$this->handleSignify($response['ttid'], $payment);
 
-		// Get Transaction Details
-		$transaction = $this->monetraInterface->transaction($transaction_id);
-		$expDate = \DateTime::createFromFormat('my', $transaction['expdate'] ?? '0101');
-		$expDateMonth = $expDate->format('n') ?? date('n');
-		$expDateYear = $expDate->format('Y') ?? date('Y');
-
-		$payment->setTransactionId($transaction_id);
-		$payment->setCcApproval($transaction['cv'] ?? 'GOOD');
-		$payment->setCcAvsStatus($transaction['avs'] ?? 'GOOD');
-		$payment->setCcExpMonth($expDateMonth);
-		$payment->setCcExpYear($expDateYear);
+		$payment->setTransactionId($response['ttid']);
 
 		return $this;
 	}
@@ -451,6 +432,24 @@ class ClientTicket extends \Magento\Payment\Model\Method\Cc
 			$token = $transaction_id_parts[1];
 		}
 		return [$ttid, $token];
+	}
+
+	private function handleSignify($transaction_id, $payment)
+	{
+		// Maping 
+		$CcvStatusMap = ['GOOD' => 'M', 'BAD' => 'N', 'UNKNOWN' => 'M'];
+		$AvsStatusMap = ['GOOD' => 'Y', 'BAD' => 'N', 'STREET' => 'Z', 'ZIP' => 'A', 'UNKNOWN' => 'Y'];
+
+		// Get Transaction Details
+		$transaction = $this->monetraInterface->transaction($transaction_id);
+		$expDate = \DateTime::createFromFormat('my', $transaction['expdate'] ?? '0101');
+		$expDateMonth = $expDate->format('n') ?? date('n');
+		$expDateYear = $expDate->format('Y') ?? date('Y');
+
+		$payment->setCcCidStatus($CcvStatusMap[$transaction['cv'] ?? 'BAD']);
+		$payment->setCcAvsStatus($AvsStatusMap[$transaction['avs'] ?? 'BAD']);
+		$payment->setCcExpMonth($expDateMonth);
+		$payment->setCcExpYear($expDateYear);
 	}
 
 }

--- a/Model/ClientTicket.php
+++ b/Model/ClientTicket.php
@@ -281,7 +281,19 @@ class ClientTicket extends \Magento\Payment\Model\Method\Cc
 			$this->handleAuthResponse($response, $payment, $paymentToken);
 		}
 
-		$payment->setTransactionId($response['ttid']);
+		$transaction_id = $response['ttid'];
+
+		// Get Transaction Details
+		$transaction = $this->monetraInterface->transaction($transaction_id);
+		$expDate = \DateTime::createFromFormat('my', $transaction['expdate'] ?? '0101');
+		$expDateMonth = $expDate->format('n') ?? date('n');
+		$expDateYear = $expDate->format('Y') ?? date('Y');
+
+		$payment->setTransactionId($transaction_id);
+		$payment->setCcApproval($transaction['cv'] ?? 'GOOD');
+		$payment->setCcAvsStatus($transaction['avs'] ?? 'GOOD');
+		$payment->setCcExpMonth($expDateMonth);
+		$payment->setCcExpYear($expDateYear);
 
 		return $this;
 	}

--- a/Model/ClientTicket.php
+++ b/Model/ClientTicket.php
@@ -168,11 +168,22 @@ class ClientTicket extends \Magento\Payment\Model\Method\Cc
 		}
 
 		$transaction_id = $response['ttid'];
+
 		if ($auto_tokenize && !$customer_selected_tokenize && isset($response['token'])) {
 			$transaction_id .= "-" . $response['token'];
 		}
 
+		// Get Transaction Details
+		$transaction = $this->monetraInterface->transaction($transaction_id);
+		$expDate = \DateTime::createFromFormat('my', $transaction['expdate'] ?? '0101');
+		$expDateMonth = $expDate->format('n') ?? date('n');
+		$expDateYear = $expDate->format('Y') ?? date('Y');
+
 		$payment->setTransactionId($transaction_id);
+		$payment->setCcApproval($transaction['cv'] ?? 'GOOD');
+		$payment->setCcAvsStatus($transaction['avs'] ?? 'GOOD');
+		$payment->setCcExpMonth($expDateMonth);
+		$payment->setCcExpYear($expDateYear);
 		$payment->setIsTransactionClosed(false);
 
 		return $this;


### PR DESCRIPTION
### Enable CCV and AVS Status in Magento 2 for Signifyd

#### Description

With this change, the values in the columns `cc_cid_status` and `cc_avs_status` in the table `sales_order_payment` will be populated based on the Transaction information of the Payment.

This values can be used by Signifyd to score the transaction.

#### Justification

Needed to integrate with [Signifyd](https://www.signifyd.com/) decisions, the status are mapped based on the AVS responses.

[Read more about AVS Codes](https://community.signifyd.com/support/s/article/avs-and-cvv-mapping?language=en_US)